### PR TITLE
feature: split search query on whitespace

### DIFF
--- a/script/wallhaven-service.js
+++ b/script/wallhaven-service.js
@@ -34,7 +34,7 @@ class WallhavenService {
 		showLoading();
 
 		try {
-			const keywords = settings.getSearchQuery().split(/\s*[,;|]\s*/);
+			const keywords = settings.getSearchQuery().split(/[\s,;|]+/);
 
 			const wallpaperPromises = keywords
 				.map(keyword => keyword.trim())


### PR DESCRIPTION
## Summary

- Add whitespace as a search query delimiter alongside `,;|`
- Changes the split regex from `/\s*[,;|]\s*/` to `/[\s,;|]+/`